### PR TITLE
deasync version issue fixed

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,9 +10,9 @@
   "main": "../lib/db",
   "dependencies": {
     "async": "~0.2.9",
+    "deasync": "^0.1.4",
     "rethinkdb": "~2.0.0",
-    "underscore": "~1.5.1",
-    "deasync": "^0.0.10"
+    "underscore": "~1.5.1"
   },
   "devDependencies": {
     "chai": "~1.7.2",


### PR DESCRIPTION
Hi, Rob! I have caught the issue with your fine library. It cannot be installed at all. Neither in Ubuntu, nor in Windows. This is because the deasync version (it dont want to be instaled).