### PR TITLE
fixed id of the returned object on save

### DIFF
--- a/lib/table.js
+++ b/lib/table.js
@@ -77,10 +77,10 @@ var Table = function(config, tableName){
             //loop the generated keys and assign, then pass it all back
             if(_.isArray(thing)){
               for(var i = 0;i < result.generated_keys.length; i++){
-                thing[i] = result.generated_keys[i];
+                thing[i].id = result.generated_keys[i];
               }
             }else{
-              thing.id = _.first(result.generated_keys[0]);
+              thing.id = result.generated_keys[0];
             }
           }
         }


### PR DESCRIPTION
When saving a single item, the Save function was returning the newly created object with the incorrect id. It was just returning the first character of the id field.